### PR TITLE
Update fixture when new villains are added

### DIFF
--- a/data/rounds.js
+++ b/data/rounds.js
@@ -60,6 +60,10 @@ const roundsData = {
       {
         "1": "Syndrome",
         "2": "Lotso"
+      },
+      {
+        "1": "Madame Mim",
+        "2": "Oogie Boogie"
       }
     ],
     [
@@ -102,6 +106,10 @@ const roundsData = {
       {
         "1": "Madame Mim",
         "2": "Hades"
+      },
+      {
+        "1": "Oogie Boogie",
+        "2": "Lotso"
       }
     ],
     [
@@ -144,6 +152,10 @@ const roundsData = {
       {
         "1": "Lotso",
         "2": "Lady Tremaine"
+      },
+      {
+        "1": "Hades",
+        "2": "Oogie Boogie"
       }
     ],
     [
@@ -186,6 +198,10 @@ const roundsData = {
       {
         "1": "Hades",
         "2": "Scar"
+      },
+      {
+        "1": "Lady Tremaine",
+        "2": "Oogie Boogie"
       }
     ],
     [
@@ -228,6 +244,10 @@ const roundsData = {
       {
         "1": "Lady Tremaine",
         "2": "Horned King"
+      },
+      {
+        "1": "Oogie Boogie",
+        "2": "Scar"
       }
     ],
     [
@@ -270,6 +290,10 @@ const roundsData = {
       {
         "1": "Scar",
         "2": "Pete"
+      },
+      {
+        "1": "Oogie Boogie",
+        "2": "Horned King"
       }
     ],
     [
@@ -312,6 +336,10 @@ const roundsData = {
       {
         "1": "Horned King",
         "2": "Mother Gothel"
+      },
+      {
+        "1": "Pete",
+        "2": "Oogie Boogie"
       }
     ],
     [
@@ -354,6 +382,10 @@ const roundsData = {
       {
         "1": "Pete",
         "2": "Ursula"
+      },
+      {
+        "1": "Mother Gothel",
+        "2": "Oogie Boogie"
       }
     ],
     [
@@ -396,6 +428,10 @@ const roundsData = {
       {
         "1": "Mother Gothel",
         "2": "Prince John"
+      },
+      {
+        "1": "Oogie Boogie",
+        "2": "Ursula"
       }
     ],
     [
@@ -438,6 +474,10 @@ const roundsData = {
       {
         "1": "Ursula",
         "2": "Yzma"
+      },
+      {
+        "1": "Oogie Boogie",
+        "2": "Prince John"
       }
     ],
     [
@@ -480,6 +520,10 @@ const roundsData = {
       {
         "1": "Prince John",
         "2": "Dr. Facilier"
+      },
+      {
+        "1": "Yzma",
+        "2": "Oogie Boogie"
       }
     ],
     [
@@ -522,6 +566,10 @@ const roundsData = {
       {
         "1": "Yzma",
         "2": "Ratigan"
+      },
+      {
+        "1": "Dr. Facilier",
+        "2": "Oogie Boogie"
       }
     ],
     [
@@ -564,6 +612,10 @@ const roundsData = {
       {
         "1": "Dr. Facilier",
         "2": "Jafar"
+      },
+      {
+        "1": "Oogie Boogie",
+        "2": "Ratigan"
       }
     ],
     [
@@ -606,6 +658,10 @@ const roundsData = {
       {
         "1": "Ratigan",
         "2": "Queen of Hearts"
+      },
+      {
+        "1": "Oogie Boogie",
+        "2": "Jafar"
       }
     ],
     [
@@ -648,6 +704,10 @@ const roundsData = {
       {
         "1": "Jafar",
         "2": "Maleficent"
+      },
+      {
+        "1": "Queen of Hearts",
+        "2": "Oogie Boogie"
       }
     ],
     [
@@ -690,6 +750,10 @@ const roundsData = {
       {
         "1": "Queen of Hearts",
         "2": "Captain Hook"
+      },
+      {
+        "1": "Maleficent",
+        "2": "Oogie Boogie"
       }
     ],
     [
@@ -732,6 +796,10 @@ const roundsData = {
       {
         "1": "Maleficent",
         "2": "Evil Queen"
+      },
+      {
+        "1": "Oogie Boogie",
+        "2": "Captain Hook"
       }
     ],
     [
@@ -774,6 +842,10 @@ const roundsData = {
       {
         "1": "Captain Hook",
         "2": "Gaston"
+      },
+      {
+        "1": "Oogie Boogie",
+        "2": "Evil Queen"
       }
     ],
     [
@@ -816,6 +888,10 @@ const roundsData = {
       {
         "1": "Evil Queen",
         "2": "Cruella"
+      },
+      {
+        "1": "Gaston",
+        "2": "Oogie Boogie"
       }
     ],
     [
@@ -858,6 +934,10 @@ const roundsData = {
       {
         "1": "Gaston",
         "2": "Syndrome"
+      },
+      {
+        "1": "Cruella",
+        "2": "Oogie Boogie"
       }
     ],
     [
@@ -900,6 +980,10 @@ const roundsData = {
       {
         "1": "Cruella",
         "2": "Madame Mim"
+      },
+      {
+        "1": "Oogie Boogie",
+        "2": "Syndrome"
       }
     ]
   ]

--- a/data/rounds.js
+++ b/data/rounds.js
@@ -60,21 +60,9 @@ const roundsData = {
       {
         "1": "Syndrome",
         "2": "Lotso"
-      },
-      {
-        "1": "Madame Mim",
-        "2": "Oogie Boogie"
       }
     ],
     [
-      {
-        "1": "Cruella",
-        "2": "Oogie Boogie"
-      },
-      {
-        "1": "Lotso",
-        "2": "Madame Mim"
-      },
       {
         "1": "Lady Tremaine",
         "2": "Syndrome"
@@ -108,18 +96,22 @@ const roundsData = {
         "2": "Pete"
       },
       {
-        "1": "Hades",
+        "1": "Cruella",
         "2": "Scar"
+      },
+      {
+        "1": "Madame Mim",
+        "2": "Hades"
       }
     ],
     [
       {
         "1": "Scar",
-        "2": "Cruella"
+        "2": "Madame Mim"
       },
       {
         "1": "Pete",
-        "2": "Hades"
+        "2": "Cruella"
       },
       {
         "1": "Ursula",
@@ -150,26 +142,14 @@ const roundsData = {
         "2": "Horned King"
       },
       {
-        "1": "Madame Mim",
+        "1": "Lotso",
         "2": "Lady Tremaine"
-      },
-      {
-        "1": "Oogie Boogie",
-        "2": "Lotso"
       }
     ],
     [
       {
-        "1": "Cruella",
-        "2": "Lotso"
-      },
-      {
-        "1": "Lady Tremaine",
-        "2": "Oogie Boogie"
-      },
-      {
         "1": "Horned King",
-        "2": "Madame Mim"
+        "2": "Lotso"
       },
       {
         "1": "Mother Gothel",
@@ -196,141 +176,49 @@ const roundsData = {
         "2": "Yzma"
       },
       {
-        "1": "Hades",
+        "1": "Cruella",
         "2": "Ursula"
       },
       {
-        "1": "Scar",
+        "1": "Madame Mim",
         "2": "Pete"
+      },
+      {
+        "1": "Hades",
+        "2": "Scar"
       }
     ],
     [
       {
         "1": "Pete",
-        "2": "Cruella"
-      },
-      {
-        "1": "Ursula",
-        "2": "Scar"
-      },
-      {
-        "1": "Yzma",
         "2": "Hades"
       },
       {
-        "1": "Ratigan",
-        "2": "Evil Queen"
-      },
-      {
-        "1": "Queen of Hearts",
-        "2": "Maleficent"
-      },
-      {
-        "1": "Captain Hook",
-        "2": "Jafar"
-      },
-      {
-        "1": "Gaston",
-        "2": "Dr. Facilier"
-      },
-      {
-        "1": "Syndrome",
-        "2": "Prince John"
-      },
-      {
-        "1": "Madame Mim",
-        "2": "Mother Gothel"
-      },
-      {
-        "1": "Oogie Boogie",
-        "2": "Horned King"
-      },
-      {
-        "1": "Lotso",
-        "2": "Lady Tremaine"
-      }
-    ],
-    [
-      {
-        "1": "Cruella",
-        "2": "Lady Tremaine"
-      },
-      {
-        "1": "Horned King",
-        "2": "Lotso"
-      },
-      {
-        "1": "Mother Gothel",
-        "2": "Oogie Boogie"
-      },
-      {
-        "1": "Prince John",
+        "1": "Ursula",
         "2": "Madame Mim"
       },
       {
-        "1": "Dr. Facilier",
-        "2": "Syndrome"
-      },
-      {
-        "1": "Jafar",
-        "2": "Gaston"
-      },
-      {
-        "1": "Maleficent",
-        "2": "Captain Hook"
-      },
-      {
-        "1": "Evil Queen",
-        "2": "Queen of Hearts"
-      },
-      {
-        "1": "Hades",
-        "2": "Ratigan"
-      },
-      {
-        "1": "Scar",
-        "2": "Yzma"
-      },
-      {
-        "1": "Pete",
-        "2": "Ursula"
-      }
-    ],
-    [
-      {
-        "1": "Ursula",
+        "1": "Yzma",
         "2": "Cruella"
       },
       {
-        "1": "Yzma",
-        "2": "Pete"
-      },
-      {
         "1": "Ratigan",
-        "2": "Scar"
-      },
-      {
-        "1": "Queen of Hearts",
-        "2": "Hades"
-      },
-      {
-        "1": "Captain Hook",
         "2": "Evil Queen"
       },
       {
-        "1": "Gaston",
+        "1": "Queen of Hearts",
         "2": "Maleficent"
       },
       {
-        "1": "Syndrome",
+        "1": "Captain Hook",
         "2": "Jafar"
       },
       {
-        "1": "Madame Mim",
+        "1": "Gaston",
         "2": "Dr. Facilier"
       },
       {
-        "1": "Oogie Boogie",
+        "1": "Syndrome",
         "2": "Prince John"
       },
       {
@@ -344,10 +232,6 @@ const roundsData = {
     ],
     [
       {
-        "1": "Cruella",
-        "2": "Horned King"
-      },
-      {
         "1": "Mother Gothel",
         "2": "Lady Tremaine"
       },
@@ -357,68 +241,64 @@ const roundsData = {
       },
       {
         "1": "Dr. Facilier",
-        "2": "Oogie Boogie"
-      },
-      {
-        "1": "Jafar",
-        "2": "Madame Mim"
-      },
-      {
-        "1": "Maleficent",
         "2": "Syndrome"
       },
       {
-        "1": "Evil Queen",
+        "1": "Jafar",
         "2": "Gaston"
       },
       {
-        "1": "Hades",
+        "1": "Maleficent",
         "2": "Captain Hook"
       },
       {
-        "1": "Scar",
+        "1": "Evil Queen",
         "2": "Queen of Hearts"
       },
       {
-        "1": "Pete",
+        "1": "Cruella",
         "2": "Ratigan"
       },
       {
-        "1": "Ursula",
+        "1": "Madame Mim",
         "2": "Yzma"
+      },
+      {
+        "1": "Hades",
+        "2": "Ursula"
+      },
+      {
+        "1": "Scar",
+        "2": "Pete"
       }
     ],
     [
       {
-        "1": "Yzma",
-        "2": "Cruella"
-      },
-      {
-        "1": "Ratigan",
-        "2": "Ursula"
-      },
-      {
-        "1": "Queen of Hearts",
-        "2": "Pete"
-      },
-      {
-        "1": "Captain Hook",
+        "1": "Ursula",
         "2": "Scar"
       },
       {
-        "1": "Gaston",
+        "1": "Yzma",
         "2": "Hades"
       },
       {
-        "1": "Syndrome",
+        "1": "Ratigan",
+        "2": "Madame Mim"
+      },
+      {
+        "1": "Queen of Hearts",
+        "2": "Cruella"
+      },
+      {
+        "1": "Captain Hook",
         "2": "Evil Queen"
       },
       {
-        "1": "Madame Mim",
+        "1": "Gaston",
         "2": "Maleficent"
       },
       {
-        "1": "Oogie Boogie",
+        "1": "Syndrome",
         "2": "Jafar"
       },
       {
@@ -436,10 +316,6 @@ const roundsData = {
     ],
     [
       {
-        "1": "Cruella",
-        "2": "Mother Gothel"
-      },
-      {
         "1": "Prince John",
         "2": "Horned King"
       },
@@ -453,60 +329,56 @@ const roundsData = {
       },
       {
         "1": "Maleficent",
-        "2": "Oogie Boogie"
-      },
-      {
-        "1": "Evil Queen",
-        "2": "Madame Mim"
-      },
-      {
-        "1": "Hades",
         "2": "Syndrome"
       },
       {
-        "1": "Scar",
+        "1": "Evil Queen",
         "2": "Gaston"
       },
       {
-        "1": "Pete",
+        "1": "Cruella",
         "2": "Captain Hook"
       },
       {
-        "1": "Ursula",
+        "1": "Madame Mim",
         "2": "Queen of Hearts"
       },
       {
-        "1": "Yzma",
+        "1": "Hades",
         "2": "Ratigan"
+      },
+      {
+        "1": "Scar",
+        "2": "Yzma"
+      },
+      {
+        "1": "Pete",
+        "2": "Ursula"
       }
     ],
     [
       {
-        "1": "Ratigan",
-        "2": "Cruella"
-      },
-      {
-        "1": "Queen of Hearts",
-        "2": "Yzma"
-      },
-      {
-        "1": "Captain Hook",
-        "2": "Ursula"
-      },
-      {
-        "1": "Gaston",
+        "1": "Yzma",
         "2": "Pete"
       },
       {
-        "1": "Syndrome",
+        "1": "Ratigan",
         "2": "Scar"
       },
       {
-        "1": "Madame Mim",
+        "1": "Queen of Hearts",
         "2": "Hades"
       },
       {
-        "1": "Oogie Boogie",
+        "1": "Captain Hook",
+        "2": "Madame Mim"
+      },
+      {
+        "1": "Gaston",
+        "2": "Cruella"
+      },
+      {
+        "1": "Syndrome",
         "2": "Evil Queen"
       },
       {
@@ -528,10 +400,6 @@ const roundsData = {
     ],
     [
       {
-        "1": "Cruella",
-        "2": "Prince John"
-      },
-      {
         "1": "Dr. Facilier",
         "2": "Mother Gothel"
       },
@@ -548,58 +416,54 @@ const roundsData = {
         "2": "Lotso"
       },
       {
-        "1": "Hades",
-        "2": "Oogie Boogie"
-      },
-      {
-        "1": "Scar",
-        "2": "Madame Mim"
-      },
-      {
-        "1": "Pete",
+        "1": "Cruella",
         "2": "Syndrome"
       },
       {
-        "1": "Ursula",
+        "1": "Madame Mim",
         "2": "Gaston"
       },
       {
-        "1": "Yzma",
+        "1": "Hades",
         "2": "Captain Hook"
       },
       {
-        "1": "Ratigan",
+        "1": "Scar",
         "2": "Queen of Hearts"
+      },
+      {
+        "1": "Pete",
+        "2": "Ratigan"
+      },
+      {
+        "1": "Ursula",
+        "2": "Yzma"
       }
     ],
     [
       {
-        "1": "Queen of Hearts",
-        "2": "Cruella"
-      },
-      {
-        "1": "Captain Hook",
-        "2": "Ratigan"
-      },
-      {
-        "1": "Gaston",
-        "2": "Yzma"
-      },
-      {
-        "1": "Syndrome",
+        "1": "Ratigan",
         "2": "Ursula"
       },
       {
-        "1": "Madame Mim",
+        "1": "Queen of Hearts",
         "2": "Pete"
       },
       {
-        "1": "Oogie Boogie",
+        "1": "Captain Hook",
         "2": "Scar"
       },
       {
-        "1": "Lotso",
+        "1": "Gaston",
         "2": "Hades"
+      },
+      {
+        "1": "Syndrome",
+        "2": "Madame Mim"
+      },
+      {
+        "1": "Lotso",
+        "2": "Cruella"
       },
       {
         "1": "Lady Tremaine",
@@ -620,10 +484,6 @@ const roundsData = {
     ],
     [
       {
-        "1": "Cruella",
-        "2": "Dr. Facilier"
-      },
-      {
         "1": "Jafar",
         "2": "Prince John"
       },
@@ -636,66 +496,62 @@ const roundsData = {
         "2": "Horned King"
       },
       {
-        "1": "Hades",
+        "1": "Cruella",
         "2": "Lady Tremaine"
       },
       {
-        "1": "Scar",
+        "1": "Madame Mim",
         "2": "Lotso"
       },
       {
-        "1": "Pete",
-        "2": "Oogie Boogie"
-      },
-      {
-        "1": "Ursula",
-        "2": "Madame Mim"
-      },
-      {
-        "1": "Yzma",
+        "1": "Hades",
         "2": "Syndrome"
       },
       {
-        "1": "Ratigan",
+        "1": "Scar",
         "2": "Gaston"
       },
       {
-        "1": "Queen of Hearts",
+        "1": "Pete",
         "2": "Captain Hook"
+      },
+      {
+        "1": "Ursula",
+        "2": "Queen of Hearts"
+      },
+      {
+        "1": "Yzma",
+        "2": "Ratigan"
       }
     ],
     [
       {
-        "1": "Captain Hook",
-        "2": "Cruella"
-      },
-      {
-        "1": "Gaston",
-        "2": "Queen of Hearts"
-      },
-      {
-        "1": "Syndrome",
-        "2": "Ratigan"
-      },
-      {
-        "1": "Madame Mim",
+        "1": "Queen of Hearts",
         "2": "Yzma"
       },
       {
-        "1": "Oogie Boogie",
+        "1": "Captain Hook",
         "2": "Ursula"
       },
       {
-        "1": "Lotso",
+        "1": "Gaston",
         "2": "Pete"
       },
       {
-        "1": "Lady Tremaine",
+        "1": "Syndrome",
         "2": "Scar"
       },
       {
-        "1": "Horned King",
+        "1": "Lotso",
         "2": "Hades"
+      },
+      {
+        "1": "Lady Tremaine",
+        "2": "Madame Mim"
+      },
+      {
+        "1": "Horned King",
+        "2": "Cruella"
       },
       {
         "1": "Mother Gothel",
@@ -712,15 +568,99 @@ const roundsData = {
     ],
     [
       {
-        "1": "Cruella",
-        "2": "Jafar"
-      },
-      {
         "1": "Maleficent",
         "2": "Dr. Facilier"
       },
       {
         "1": "Evil Queen",
+        "2": "Prince John"
+      },
+      {
+        "1": "Cruella",
+        "2": "Mother Gothel"
+      },
+      {
+        "1": "Madame Mim",
+        "2": "Horned King"
+      },
+      {
+        "1": "Hades",
+        "2": "Lady Tremaine"
+      },
+      {
+        "1": "Scar",
+        "2": "Lotso"
+      },
+      {
+        "1": "Pete",
+        "2": "Syndrome"
+      },
+      {
+        "1": "Ursula",
+        "2": "Gaston"
+      },
+      {
+        "1": "Yzma",
+        "2": "Captain Hook"
+      },
+      {
+        "1": "Ratigan",
+        "2": "Queen of Hearts"
+      }
+    ],
+    [
+      {
+        "1": "Captain Hook",
+        "2": "Ratigan"
+      },
+      {
+        "1": "Gaston",
+        "2": "Yzma"
+      },
+      {
+        "1": "Syndrome",
+        "2": "Ursula"
+      },
+      {
+        "1": "Lotso",
+        "2": "Pete"
+      },
+      {
+        "1": "Lady Tremaine",
+        "2": "Scar"
+      },
+      {
+        "1": "Horned King",
+        "2": "Hades"
+      },
+      {
+        "1": "Mother Gothel",
+        "2": "Madame Mim"
+      },
+      {
+        "1": "Prince John",
+        "2": "Cruella"
+      },
+      {
+        "1": "Dr. Facilier",
+        "2": "Evil Queen"
+      },
+      {
+        "1": "Jafar",
+        "2": "Maleficent"
+      }
+    ],
+    [
+      {
+        "1": "Evil Queen",
+        "2": "Jafar"
+      },
+      {
+        "1": "Cruella",
+        "2": "Dr. Facilier"
+      },
+      {
+        "1": "Madame Mim",
         "2": "Prince John"
       },
       {
@@ -741,36 +681,24 @@ const roundsData = {
       },
       {
         "1": "Yzma",
-        "2": "Oogie Boogie"
-      },
-      {
-        "1": "Ratigan",
-        "2": "Madame Mim"
-      },
-      {
-        "1": "Queen of Hearts",
         "2": "Syndrome"
       },
       {
-        "1": "Captain Hook",
+        "1": "Ratigan",
         "2": "Gaston"
+      },
+      {
+        "1": "Queen of Hearts",
+        "2": "Captain Hook"
       }
     ],
     [
       {
         "1": "Gaston",
-        "2": "Cruella"
-      },
-      {
-        "1": "Syndrome",
-        "2": "Captain Hook"
-      },
-      {
-        "1": "Madame Mim",
         "2": "Queen of Hearts"
       },
       {
-        "1": "Oogie Boogie",
+        "1": "Syndrome",
         "2": "Ratigan"
       },
       {
@@ -795,11 +723,15 @@ const roundsData = {
       },
       {
         "1": "Dr. Facilier",
-        "2": "Evil Queen"
+        "2": "Madame Mim"
       },
       {
         "1": "Jafar",
-        "2": "Maleficent"
+        "2": "Cruella"
+      },
+      {
+        "1": "Maleficent",
+        "2": "Evil Queen"
       }
     ],
     [
@@ -808,7 +740,7 @@ const roundsData = {
         "2": "Maleficent"
       },
       {
-        "1": "Evil Queen",
+        "1": "Madame Mim",
         "2": "Jafar"
       },
       {
@@ -837,28 +769,16 @@ const roundsData = {
       },
       {
         "1": "Queen of Hearts",
-        "2": "Oogie Boogie"
+        "2": "Syndrome"
       },
       {
         "1": "Captain Hook",
-        "2": "Madame Mim"
-      },
-      {
-        "1": "Gaston",
-        "2": "Syndrome"
+        "2": "Gaston"
       }
     ],
     [
       {
         "1": "Syndrome",
-        "2": "Cruella"
-      },
-      {
-        "1": "Madame Mim",
-        "2": "Gaston"
-      },
-      {
-        "1": "Oogie Boogie",
         "2": "Captain Hook"
       },
       {
@@ -891,12 +811,16 @@ const roundsData = {
       },
       {
         "1": "Maleficent",
-        "2": "Evil Queen"
+        "2": "Madame Mim"
+      },
+      {
+        "1": "Evil Queen",
+        "2": "Cruella"
       }
     ],
     [
       {
-        "1": "Cruella",
+        "1": "Madame Mim",
         "2": "Evil Queen"
       },
       {
@@ -933,22 +857,10 @@ const roundsData = {
       },
       {
         "1": "Gaston",
-        "2": "Oogie Boogie"
-      },
-      {
-        "1": "Syndrome",
-        "2": "Madame Mim"
+        "2": "Syndrome"
       }
     ],
     [
-      {
-        "1": "Madame Mim",
-        "2": "Cruella"
-      },
-      {
-        "1": "Oogie Boogie",
-        "2": "Syndrome"
-      },
       {
         "1": "Lotso",
         "2": "Gaston"
@@ -984,6 +896,10 @@ const roundsData = {
       {
         "1": "Evil Queen",
         "2": "Hades"
+      },
+      {
+        "1": "Cruella",
+        "2": "Madame Mim"
       }
     ]
   ]

--- a/data/villains.js
+++ b/data/villains.js
@@ -63,10 +63,6 @@ const villainsData = [
     "img": "mim.jpg"
   },
   {
-    "name": "Oogie Boogie",
-    "img": "oogie.jpg"
-  },
-  {
     "name": "Lotso",
     "img": "lotso.jpg"
   },
@@ -105,5 +101,9 @@ const villainsData = [
   {
     "name": "Cruella",
     "img": "cruella.jpg"
+  },
+  {
+    "name": "Oogie Boogie",
+    "img": "oogie.jpg"
   },
 ];

--- a/src/app.js
+++ b/src/app.js
@@ -189,7 +189,7 @@ class Round {
      * @returns {Round}
      */
     copy() {
-        const pairs = this.pairs.map(Pair.copy);
+        const pairs = this.pairs.map((p) => p.copy());
         const round = new Round(pairs);
         return round;
     }
@@ -351,7 +351,7 @@ function getRoundsBerger(villains) {
                 pairs.push(new Pair(villains[idx1], villains[idx2]));
             }
         }
-        rounds.push(pairs);
+        rounds.push(new Round(pairs));
     }
 
     return rounds;
@@ -373,11 +373,11 @@ function getRoundsBerger(villains) {
  */
 function mergeRounds(a, b) {
     // The result is a shallow copy of A
-    const result = a.map(Round.copy);
+    const result = a.map((r) => r.copy());
 
     // Extract pairings from B not in A
     const fixA = new Fixture(1, a);
-    const newPairs = b
+    let newPairs = b
         .flatMap((r) => r.pairs)
         .filter((p) => ! fixA.contains(p));
 
@@ -388,9 +388,9 @@ function mergeRounds(a, b) {
     // Add pairs to rounds of A equal to the difference
     for (let round of result) {
         // Filter pairs from B that can be added to this round
-        const validPairs = newPairs
+        let validPairs = newPairs
             .filter((bp) =>
-                ! round.some((ap) => ap.intersects(bp));
+                ! round.some((ap) => ap.intersects(bp)));
     
         // Add pairs to A
         validPairs = validPairs.splice(0, Math.min(diff, validPairs.length));
@@ -549,7 +549,7 @@ function loadFixture(villains, fixtureData, results) {
             );
             roundPairs.push(pair);
         });
-        fixture.rounds.push(roundPairs);
+        fixture.rounds.push(new Round(roundPairs));
     });
     setResultsIntoFixture(fixture, results);
     return fixture;

--- a/src/app.js
+++ b/src/app.js
@@ -199,7 +199,7 @@ class Round {
      * @param {Pair} pair A pair to search for.
      * @returns {boolean}
      */
-    contains(pair) {
+    includes(pair) {
         for (let p of this.pairs) {
             if (p.equals(pair)) {
                 return true;
@@ -238,9 +238,9 @@ class Fixture {
      * @param {Pair} pair A pair to search for.
      * @returns {boolean}
      */
-    contains(pair) {
+    includes(pair) {
         for (let r of this.rounds) {
-            if (r.contains(pair)) {
+            if (r.includes(pair)) {
                 return true;
             }
         }
@@ -379,7 +379,7 @@ function mergeRounds(a, b) {
     const fixA = new Fixture(1, a);
     let newPairs = b
         .flatMap((r) => r.pairs)
-        .filter((p) => ! fixA.contains(p));
+        .filter((p) => ! fixA.includes(p));
 
     // Calculate difference of round length between A and B
     const roundLength = b[0].length();
@@ -390,14 +390,14 @@ function mergeRounds(a, b) {
         // Filter pairs from B that can be added to this round
         let validPairs = newPairs
             .filter((bp) =>
-                ! round.some((ap) => ap.intersects(bp)));
+                ! round.pairs.some((ap) => ap.intersects(bp)));
     
         // Add pairs to A
         validPairs = validPairs.splice(0, Math.min(diff, validPairs.length));
         validPairs.forEach((bp) => round.push(bp));
 
         // Remove from pending
-        newPairs = newPairs.filter((bp) => ! validPairs.contains(bp));
+        newPairs = newPairs.filter((bp) => ! validPairs.includes(bp));
     }
 
     // Remaining pairs are placed into additional rounds
@@ -723,14 +723,14 @@ function onPageLoad(villainsData, roundsData, resultsData) {
     const villains = loadVillains(villainsData);
 
     // A) Either load fixture from rounds data
-    //const fixture = loadFixture(villains, roundsData, resultsData);
+    const fixture = loadFixture(villains, roundsData, resultsData);
     // B) or Generate new fixture from villains data
     //const fixture = generateFixture(villains, resultsData);
     //console.log(fixtureToJson(fixture));
     // C) or Updtate existing fixture with new villains data
-    const oldFixture = loadFixture(villains, roundsData, []);
-    const fixture = generateFixture(villains, resultsData, oldFixture);
-    console.log(fixtureToJson(fixture));
+    //const oldFixture = loadFixture(villains, roundsData, []);
+    //const fixture = generateFixture(villains, resultsData, oldFixture);
+    //console.log(fixtureToJson(fixture));
 
     // Draw fixture as HTML
     drawFixtureHtml(fixture);


### PR DESCRIPTION
New behaviour to execute on page load, that updates the fixture rounds with new villains. This replaces the old functionality that had to recreate the fixture from scratch and generated many file differences.